### PR TITLE
Fix thejsj/rethinkdb-init#6 new RethinkDB errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var rethinkdbInit = function (r) {
    * @param <Error>
    */
   var existsHandler = function (err) {
-    if (err.name === 'RqlRuntimeError' && err.msg.indexOf('already exists')) return;
+    if (err.name === 'ReqlOpFailedError' && err.msg.indexOf('already exists')) return;
     throw err;
   };
 


### PR DESCRIPTION
Thanks to @MethodGrab's detailed issue report, I had no trouble replacing the name of the error in `existsHandler`. (I came here from your passport-rethinkdb-tutorial 😄)
