### PR TITLE
Call `indexWait` once per table

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,10 +45,7 @@ var rethinkdbInit = function (r) {
       return r.db(db).table(table.name)
         .indexCreate(index.name, opts[0], opts[1])
         .run(conn)
-        .catch(existsHandler)
-        .then(function () {
-          return r.db(db).table(table.name).indexWait().run(conn);
-        });
+        .catch(existsHandler);
     });
   };
 
@@ -76,6 +73,9 @@ var rethinkdbInit = function (r) {
           if (table.indexes === undefined) return true;
           if (!Array.isArray(table.indexes)) throw new TypeError('Table indexes attribute should be an Array.');
           return q.all(mapIndexes(table, db, conn));
+        })
+        .then(function () {
+          return r.db(db).table(table.name).indexWait().run(conn);
         });
     });
   };


### PR DESCRIPTION
From my last PR (#10), there was no reason to be calling `.indexWait()` for every secondary index. It didn't necessarily have any consequences, just a little cleaner this way.
